### PR TITLE
Fix NBA pipeline bugs across all stages

### DIFF
--- a/docs/win/basketball/scripts/00_parsing/dedupe.py
+++ b/docs/win/basketball/scripts/00_parsing/dedupe.py
@@ -4,7 +4,7 @@
 import csv
 import pandas as pd
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 # =========================
 # LOGGER UTILITY
@@ -62,7 +62,7 @@ with open(LOG_FILE, "w", encoding="utf-8") as f:
 
 def log(msg):
     with open(LOG_FILE, "a", encoding="utf-8") as f:
-        f.write(f"{datetime.utcnow().isoformat()} | {msg}\n")
+        f.write(f"{datetime.now(timezone.utc).isoformat()} | {msg}\n")
 
 # =========================
 # DEDUPE FUNCTION

--- a/docs/win/basketball/scripts/00_parsing/dk.py
+++ b/docs/win/basketball/scripts/00_parsing/dk.py
@@ -6,7 +6,7 @@ import re
 import csv
 import pandas as pd
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # ----------------------------
 # LOGGER UTILITY
@@ -58,7 +58,7 @@ with open(LOG_FILE, "w", encoding="utf-8") as f:
 
 def log(msg: str) -> None:
     with open(LOG_FILE, "a", encoding="utf-8") as f:
-        f.write(f"{datetime.utcnow().isoformat()} | {msg}\n")
+        f.write(f"{datetime.now(timezone.utc).isoformat()} | {msg}\n")
 
 
 # ----------------------------

--- a/docs/win/basketball/scripts/00_parsing/drat.py
+++ b/docs/win/basketball/scripts/00_parsing/drat.py
@@ -6,7 +6,7 @@ import re
 import csv
 import pandas as pd
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict
 
 # =========================
@@ -60,7 +60,7 @@ with open(LOG_FILE, "w", encoding="utf-8") as f:
 
 def log(msg: str) -> None:
     with open(LOG_FILE, "a", encoding="utf-8") as f:
-        f.write(f"{datetime.utcnow().isoformat()} | {msg}\n")
+        f.write(f"{datetime.now(timezone.utc).isoformat()} | {msg}\n")
 
 # =========================
 # ARGS / INPUT

--- a/docs/win/basketball/scripts/00_parsing/name_normalization.py
+++ b/docs/win/basketball/scripts/00_parsing/name_normalization.py
@@ -4,7 +4,7 @@
 import csv
 import pandas as pd
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 # =========================
 # LOGGER UTILITY
@@ -67,7 +67,7 @@ with open(LOG_FILE, "w", encoding="utf-8") as f:
 
 def log(msg: str) -> None:
     with open(LOG_FILE, "a", encoding="utf-8") as f:
-        f.write(f"{datetime.utcnow().isoformat()} | {msg}\n")
+        f.write(f"{datetime.now(timezone.utc).isoformat()} | {msg}\n")
 
 # =========================
 # LOAD TEAM MAPS (CASE INSENSITIVE)

--- a/docs/win/basketball/scripts/01_merge/build_juice_files.py
+++ b/docs/win/basketball/scripts/01_merge/build_juice_files.py
@@ -6,7 +6,7 @@ import glob
 import sys
 import traceback
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from scipy.stats import norm, poisson
 
 # ============================================================
@@ -104,7 +104,7 @@ def main():
 
     with open(ERROR_LOG, "w") as log:
         log.write("=== BUILD JUICE FILES RUN ===\n")
-        log.write(f"{datetime.utcnow().isoformat()}Z\n\n")
+        log.write(f"{datetime.now(timezone.utc).isoformat()}Z\n\n")
 
     try:
 
@@ -122,6 +122,11 @@ def main():
             df = pd.read_csv(file_path)
 
             if df.empty:
+                continue
+
+            if "market" not in df.columns or "game_date" not in df.columns:
+                audit(ERROR_LOG, "BUILD_JUICE", "SKIP",
+                      f"Missing required columns (market/game_date) in {file_path}")
                 continue
 
             market = df["market"].iloc[0]
@@ -255,9 +260,13 @@ def main():
                 acc_home_dec = fair_home_dec * (1 + SPREAD_EDGE)
                 acc_away_dec = fair_away_dec * (1 + SPREAD_EDGE)
 
+                fair_home.append(fair_home_dec)
+                fair_away.append(fair_away_dec)
                 acc_home.append(acc_home_dec)
                 acc_away.append(acc_away_dec)
 
+            spread_df["fair_home_spread_decimal"] = fair_home
+            spread_df["fair_away_spread_decimal"] = fair_away
             spread_df["home_acceptable_spread_decimal"] = acc_home
             spread_df["away_acceptable_spread_decimal"] = acc_away
 

--- a/docs/win/basketball/scripts/01_merge/merge_intake.py
+++ b/docs/win/basketball/scripts/01_merge/merge_intake.py
@@ -137,14 +137,23 @@ for league, slate_date in slates:
             team_key = build_team_set(p)
 
             if team_key in book_team_map:
-                d = book_team_map[team_key]
+                d_raw = book_team_map[team_key]
 
                 log(
-                    f"ORIENTATION MISMATCH | {league} {slate_date} | "
+                    f"ORIENTATION MISMATCH (swapping) | {league} {slate_date} | "
                     f"PRED: {p['home_team']} vs {p['away_team']} | "
-                    f"BOOK: {d['home_team']} vs {d['away_team']}"
+                    f"BOOK: {d_raw['home_team']} vs {d_raw['away_team']}"
                 )
-                continue
+
+                # Book has home/away flipped relative to prediction — swap fields
+                d = dict(d_raw)
+                d["away_spread"]               = d_raw.get("home_spread", "")
+                d["home_spread"]               = d_raw.get("away_spread", "")
+                d["away_dk_spread_american"]   = d_raw.get("home_dk_spread_american", "")
+                d["home_dk_spread_american"]   = d_raw.get("away_dk_spread_american", "")
+                d["away_dk_moneyline_american"] = d_raw.get("home_dk_moneyline_american", "")
+                d["home_dk_moneyline_american"] = d_raw.get("away_dk_moneyline_american", "")
+                # total/over/under are symmetric — no swap needed
 
             else:
                 log(

--- a/docs/win/basketball/scripts/02_juice/apply_moneyline_juice.py
+++ b/docs/win/basketball/scripts/02_juice/apply_moneyline_juice.py
@@ -78,6 +78,7 @@ def normalize_american_value(val):
     try:
         return float(text)
     except:
+        log(f"WARN: invalid American odds value: {val!r}")
         return None
 
 
@@ -142,8 +143,11 @@ def clear_old_moneyline_outputs():
 # LOAD CONFIG
 # =========================
 
-NBA_JT = pd.read_csv(NBA_CONFIG)
-NCAAB_JT = pd.read_csv(NCAAB_CONFIG)
+try:
+    NBA_JT = pd.read_csv(NBA_CONFIG)
+    NCAAB_JT = pd.read_csv(NCAAB_CONFIG)
+except FileNotFoundError as e:
+    raise SystemExit(f"ERROR: Missing juice config file — {e}") from e
 
 
 # =========================

--- a/docs/win/basketball/scripts/02_juice/apply_spread_juice.py
+++ b/docs/win/basketball/scripts/02_juice/apply_spread_juice.py
@@ -47,8 +47,11 @@ ERROR_LOG = ERROR_DIR / "apply_spread_juice.txt"
 # LOAD CONFIG
 # =========================
 
-NBA_JUICE_TABLE = pd.read_csv(NBA_CONFIG)
-NCAAB_JUICE_TABLE = pd.read_csv(NCAAB_CONFIG)
+try:
+    NBA_JUICE_TABLE = pd.read_csv(NBA_CONFIG)
+    NCAAB_JUICE_TABLE = pd.read_csv(NCAAB_CONFIG)
+except FileNotFoundError as e:
+    raise SystemExit(f"ERROR: Missing juice config file — {e}") from e
 
 # =========================
 # CLEAN OLD FILES

--- a/docs/win/basketball/scripts/02_juice/apply_total_juice.py
+++ b/docs/win/basketball/scripts/02_juice/apply_total_juice.py
@@ -65,12 +65,16 @@ def log(msg):
 # CONFIG LOAD
 # =========================
 
-NBA_JUICE = pd.read_csv(NBA_CONFIG)
+try:
+    NBA_JUICE = pd.read_csv(NBA_CONFIG)
+    NCAAB_JUICE = pd.read_csv(NCAAB_CONFIG)
+except FileNotFoundError as e:
+    raise SystemExit(f"ERROR: Missing juice config file — {e}") from e
+
 NBA_JUICE["band_min"] = pd.to_numeric(NBA_JUICE["band_min"], errors="coerce")
 NBA_JUICE["band_max"] = pd.to_numeric(NBA_JUICE["band_max"], errors="coerce")
 NBA_JUICE["extra_juice"] = pd.to_numeric(NBA_JUICE["extra_juice"], errors="coerce")
 
-NCAAB_JUICE = pd.read_csv(NCAAB_CONFIG)
 NCAAB_JUICE["over_under"] = pd.to_numeric(NCAAB_JUICE["over_under"], errors="coerce")
 NCAAB_JUICE["extra_juice"] = pd.to_numeric(NCAAB_JUICE["extra_juice"], errors="coerce")
 

--- a/docs/win/basketball/scripts/03_edges/compute_ev_kelly.py
+++ b/docs/win/basketball/scripts/03_edges/compute_ev_kelly.py
@@ -147,9 +147,9 @@ def process_totals(df):
 
     df = to_numeric(df, numeric_cols)
 
-    # convert fair odds → probabilities
-    df["over_prob"] = 1 / df["fair_over"]
-    df["under_prob"] = 1 / df["fair_under"]
+    # convert fair odds → probabilities (guard against zero/NaN)
+    df["over_prob"] = 1 / df["fair_over"].where(df["fair_over"] > 0)
+    df["under_prob"] = 1 / df["fair_under"].where(df["fair_under"] > 0)
 
     df["over_edge_pct"] = df["over_edge"] * 100
     df["under_edge_pct"] = df["under_edge"] * 100

--- a/docs/win/basketball/scripts/04_select/select_bets.py
+++ b/docs/win/basketball/scripts/04_select/select_bets.py
@@ -73,7 +73,10 @@ def extract_date(filename):
     return m.group(0) if m else None
 
 def market_cfg(market, market_type):
-    return CONFIG["markets"][market.lower()][market_type]
+    try:
+        return CONFIG["markets"][market.lower()][market_type]
+    except KeyError:
+        raise KeyError(f"No config found for market={market!r}, market_type={market_type!r}")
 
 def ev_ok(ev, cfg):
     if ev is None:


### PR DESCRIPTION
- compute_ev_kelly.py: guard fair_over/fair_under against zero/NaN before dividing to avoid inf/NaN propagation
- build_juice_files.py: save fair_home/fair_away spread decimals to output (were computed but never written); add missing column guard for market/game_date; fix deprecated datetime.utcnow()
- merge_intake.py: handle orientation mismatch by swapping home/away book fields instead of silently dropping the game
- 00_parsing (dedupe, dk, drat, name_normalization): replace deprecated datetime.utcnow() with datetime.now(timezone.utc)
- apply_moneyline/spread/total_juice.py: wrap config CSV loading in try/except for clear error on missing files
- apply_moneyline_juice.py: log invalid American odds values instead of silently returning None
- select_bets.py: raise descriptive KeyError in market_cfg() instead of bare dict access

https://claude.ai/code/session_017gfnmjG1NiDyBHGNX6y5WR