### PR TITLE
Fix four pipeline bugs found in script analysis

### DIFF
--- a/docs/win/basketball/scripts/00_parsing/dk.py
+++ b/docs/win/basketball/scripts/00_parsing/dk.py
@@ -268,7 +268,7 @@ for block in blocks:
 
 if not rows:
     log("SUMMARY: wrote 0 rows")
-    raise SystemExit(0)
+    raise SystemExit(1)
 
 # ----------------------------
 # Write (FULL REBUILD FOR DAY)

--- a/docs/win/basketball/scripts/02_juice/apply_spread_juice.py
+++ b/docs/win/basketball/scripts/02_juice/apply_spread_juice.py
@@ -83,7 +83,7 @@ def validate_columns(df, cols):
 def normalize_american(val):
     if pd.isna(val):
         return None
-    text = str(val).replace("+","").strip()
+    text = str(val).strip().replace(",", "").replace("+", "")
     try:
         return float(text)
     except:

--- a/docs/win/basketball/scripts/02_juice/apply_total_juice.py
+++ b/docs/win/basketball/scripts/02_juice/apply_total_juice.py
@@ -61,6 +61,12 @@ def log(msg):
         f.write(f"{datetime.now(UTC).isoformat()} | {msg}\n")
 
 
+def atomic_write(df, path):
+    tmp = path.with_suffix(".tmp")
+    df.to_csv(tmp, index=False)
+    tmp.replace(path)
+
+
 # =========================
 # CONFIG LOAD
 # =========================
@@ -229,7 +235,7 @@ def main():
                 df = pd.read_csv(f)
                 df = apply_nba(df)
 
-                df.to_csv(OUTPUT_DIR / name, index=False)
+                atomic_write(df, OUTPUT_DIR / name)
 
                 log(f"Processed NBA file: {name}")
 
@@ -244,7 +250,7 @@ def main():
                 df = pd.read_csv(f)
                 df = apply_ncaab(df)
 
-                df.to_csv(OUTPUT_DIR / name, index=False)
+                atomic_write(df, OUTPUT_DIR / name)
 
                 log(f"Processed NCAAB file: {name}")
 

--- a/docs/win/basketball/scripts/03_edges/compute_edges.py
+++ b/docs/win/basketball/scripts/03_edges/compute_edges.py
@@ -209,8 +209,6 @@ def process_market_files(files, compute_fn, league, market):
             else:
                 df = compute_fn(df, league)
 
-            df = df.drop(columns=["home_play", "away_play"], errors="ignore")
-
             output_path = OUTPUT_DIR / f"{date}_basketball_{league}_{market}.csv"
             atomic_write_csv(df, output_path)
 


### PR DESCRIPTION
- apply_total_juice.py: replace direct to_csv with atomic write (tmp+rename) to prevent corrupt output files on crash, matching the other juice scripts
- dk.py: raise SystemExit(1) on zero parsed rows instead of SystemExit(0), so the calling workflow correctly detects a parse failure
- apply_spread_juice.py: normalize_american now strips commas before parsing, matching apply_moneyline_juice.py's handling of values like "1,110"
- compute_edges.py: remove dead drop of home_play/away_play columns that are never created anywhere in the pipeline

https://claude.ai/code/session_017gfnmjG1NiDyBHGNX6y5WR