### PR TITLE
Refactor analytics dashboards to use shared matstheme + dashboard.css

### DIFF
--- a/docs/nba_dashboard.html
+++ b/docs/nba_dashboard.html
@@ -1,90 +1,15 @@
 <!DOCTYPE html>
-
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NBA Betting Dashboard</title>
-<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Mono:wght@300;400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
-<style>
-  :root {
-    --bg: #0a0c10;
-    --bg2: #0f1218;
-    --bg3: #141820;
-    --border: #1e2530;
-    --border2: #252e3d;
-    --accent: #ff6b35;
-    --green: #00e676;
-    --red: #ff3d5a;
-    --gold: #ffd600;
-    --text: #e8edf5;
-    --text2: #8a9bb8;
-    --text3: #4a5568;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { background: var(--bg); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 14px; min-height: 100vh; }
-  header { background: linear-gradient(135deg, #0a0c10 0%, #1a0f0a 100%); border-bottom: 1px solid var(--border); padding: 24px 32px; display: flex; align-items: center; justify-content: space-between; position: sticky; top: 0; z-index: 100; backdrop-filter: blur(12px); }
-  header h1 { font-family: 'Bebas Neue', sans-serif; font-size: 2.4rem; letter-spacing: 4px; background: linear-gradient(90deg, #ff6b35, #ffffff); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-  .header-sub { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--text2); letter-spacing: 2px; text-transform: uppercase; margin-top: 2px; }
-  .status-pill { background: rgba(0,230,118,0.1); border: 1px solid rgba(0,230,118,0.3); color: var(--green); font-family: 'DM Mono', monospace; font-size: 11px; padding: 6px 14px; border-radius: 100px; letter-spacing: 1px; }
-  nav { background: var(--bg2); border-bottom: 1px solid var(--border); padding: 0 32px; display: flex; gap: 0; overflow-x: auto; }
-  nav a { color: var(--text2); text-decoration: none; font-size: 12px; font-weight: 500; letter-spacing: 1px; text-transform: uppercase; padding: 14px 20px; border-bottom: 2px solid transparent; transition: all 0.2s; white-space: nowrap; cursor: pointer; }
-  nav a:hover, nav a.active { color: var(--accent); border-bottom-color: var(--accent); }
-  main { padding: 32px; max-width: 1400px; margin: 0 auto; }
-  .section { display: none; }
-  .section.active { display: block; }
-  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 16px; margin-bottom: 32px; }
-  .stat-card { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; padding: 20px; position: relative; overflow: hidden; transition: border-color 0.2s; }
-  .stat-card:hover { border-color: var(--border2); }
-  .stat-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--accent); opacity: 0.6; }
-  .stat-card.green::before { background: var(--green); }
-  .stat-card.red::before { background: var(--red); }
-  .stat-card.gold::before { background: var(--gold); }
-  .stat-label { font-family: 'DM Mono', monospace; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--text3); margin-bottom: 10px; }
-  .stat-value { font-family: 'Bebas Neue', sans-serif; font-size: 2rem; letter-spacing: 1px; line-height: 1; }
-  .stat-value.green { color: var(--green); }
-  .stat-value.red { color: var(--red); }
-  .stat-value.gold { color: var(--gold); }
-  .stat-value.accent { color: var(--accent); }
-  .section-title { font-family: 'Bebas Neue', sans-serif; font-size: 1.4rem; letter-spacing: 3px; color: var(--text2); margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 12px; }
-  .section-title span { width: 3px; height: 20px; background: var(--accent); border-radius: 2px; display: inline-block; }
-  .table-wrap { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin-bottom: 28px; }
-  table { width: 100%; border-collapse: collapse; font-family: 'DM Mono', monospace; font-size: 12px; }
-  thead tr { background: rgba(255,107,53,0.05); border-bottom: 1px solid var(--border); }
-  th { text-align: left; padding: 12px 16px; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--text3); font-weight: 500; cursor: pointer; user-select: none; white-space: nowrap; }
-  th:hover { color: var(--accent); }
-  td { padding: 11px 16px; border-bottom: 1px solid rgba(30,37,48,0.6); white-space: nowrap; }
-  tr:last-child td { border-bottom: none; }
-  tbody tr:hover { background: rgba(255,255,255,0.02); }
-  .win { color: var(--green); }
-  .loss { color: var(--red); }
-  .push { color: var(--gold); }
-  .bar-chart { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin-bottom: 28px; }
-  .bar-row { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
-  .bar-label { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--text2); width: 140px; text-align: right; flex-shrink: 0; }
-  .bar-track { flex: 1; height: 28px; background: rgba(255,255,255,0.04); border-radius: 4px; overflow: hidden; }
-  .bar-fill { height: 100%; border-radius: 4px; display: flex; align-items: center; padding-left: 10px; font-family: 'DM Mono', monospace; font-size: 11px; font-weight: 500; transition: width 0.8s cubic-bezier(0.4,0,0.2,1); }
-  .bar-fill.win-bar { background: linear-gradient(90deg, rgba(0,230,118,0.4), rgba(0,230,118,0.15)); color: var(--green); }
-  .bar-fill.loss-bar { background: linear-gradient(90deg, rgba(255,61,90,0.4), rgba(255,61,90,0.15)); color: var(--red); }
-  .bar-fill.neutral-bar { background: linear-gradient(90deg, rgba(255,107,53,0.4), rgba(255,107,53,0.15)); color: var(--accent); }
-  .bar-meta { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--text2); width: 60px; flex-shrink: 0; }
-  .date-chart { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin-bottom: 28px; }
-  canvas { width: 100% !important; }
-  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 28px; }
-  @media (max-width: 900px) { .grid-2 { grid-template-columns: 1fr; } }
-  .search-bar { width: 100%; background: var(--bg3); border: 1px solid var(--border); border-radius: 8px; padding: 10px 16px; color: var(--text); font-family: 'DM Mono', monospace; font-size: 12px; margin-bottom: 16px; outline: none; transition: border-color 0.2s; }
-  .search-bar:focus { border-color: var(--accent); }
-  .pagination { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; flex-wrap: wrap; }
-  .page-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--text2); font-family: 'DM Mono', monospace; font-size: 11px; padding: 6px 12px; border-radius: 6px; cursor: pointer; transition: all 0.2s; }
-  .page-btn:hover, .page-btn.active { background: var(--accent); color: #000; border-color: var(--accent); }
-  .loading { text-align: center; padding: 60px; font-family: 'DM Mono', monospace; font-size: 12px; color: var(--text3); letter-spacing: 2px; }
-  .wr-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
-  .wr-high { background: rgba(0,230,118,0.15); color: var(--green); }
-  .wr-mid  { background: rgba(255,214,0,0.15);  color: var(--gold); }
-  .wr-low  { background: rgba(255,61,90,0.15);  color: var(--red); }
-</style>
+<title>NBA Analytics | EDGELYTICS</title>
+<link rel="stylesheet" href="css/matstheme.css">
+<link rel="stylesheet" href="css/dashboard.css">
+<style>:root { --sport-accent: #ff6b35; }</style>
 </head>
 <body>
+<div id="nav-placeholder"></div>
 
 <header>
   <div>
@@ -94,7 +19,7 @@
   <div class="status-pill" id="last-updated">LOADING...</div>
 </header>
 
-<nav>
+<div class="dash-tabs">
   <a class="active" onclick="showSection('market', this)">Market</a>
   <a onclick="showSection('side', this)">Side</a>
   <a onclick="showSection('edge', this)">Edge</a>
@@ -103,10 +28,9 @@
   <a onclick="showSection('date', this)">By Date</a>
   <a onclick="showSection('betlog', this)">Bet Log</a>
   <a onclick="showSection('tally', this)">Tally</a>
-</nav>
+</div>
 
 <main>
-
   <div class="stat-grid" id="stat-cards" style="display:none">
     <div class="stat-card accent">
       <div class="stat-label">Total Bets</div>
@@ -146,12 +70,10 @@
     <div class="section-title"><span></span>BY MARKET</div>
     <div class="table-wrap"><div class="loading" id="load-market">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-side">
     <div class="section-title"><span></span>BY SIDE</div>
     <div class="table-wrap"><div class="loading" id="load-side">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-edge">
     <div class="section-title"><span></span>BY EDGE BUCKET</div>
     <div class="grid-2">
@@ -167,7 +89,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-edge-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-odds">
     <div class="section-title"><span></span>BY ODDS BUCKET</div>
     <div class="grid-2">
@@ -183,7 +104,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-odds-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-kelly">
     <div class="section-title"><span></span>BY KELLY BUCKET</div>
     <div class="grid-2">
@@ -199,7 +119,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-kelly-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-date">
     <div class="section-title"><span></span>PERFORMANCE BY DATE</div>
     <div class="date-chart">
@@ -207,25 +126,22 @@
     </div>
     <div class="table-wrap"><div class="loading" id="load-date">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-betlog">
     <div class="section-title"><span></span>BET LOG</div>
     <input type="text" class="search-bar" placeholder="Search teams, market, result..." oninput="filterBetLog(this.value)">
     <div class="table-wrap" id="betlog-wrap"><div class="loading">Loading...</div></div>
     <div class="pagination" id="betlog-pages"></div>
   </div>
-
   <div class="section" id="sec-tally">
     <div class="section-title"><span></span>MARKET TALLY</div>
     <div class="bar-chart" id="tally-chart"><div class="loading">Loading...</div></div>
     <div class="table-wrap"><div class="loading" id="load-tally-table">Loading...</div></div>
   </div>
-
 </main>
 
+<script src="js/nav.js"></script>
 <script>
 const BASE = 'https://raw.githubusercontent.com/Clownworldenjoyer76/bet_tracker/main/docs/win/final_scores/deeper_summaries/nba/';
-
 const FILES = {
   nba_summary_overall:            BASE + 'nba_summary_overall.csv',
   nba_summary_by_market:          BASE + 'nba_summary_by_market.csv',
@@ -245,12 +161,10 @@ const FILES = {
   nba_total_by_odds:              BASE + 'by_market/nba_total_by_odds.csv',
   nba_total_by_side:              BASE + 'by_market/nba_total_by_side.csv',
 };
-
 const D = {};
 let betLogFiltered = [];
 let betLogPage = 0;
 const PAGE_SIZE = 50;
-
 function parseCSV(text) {
   const lines = text.trim().split('\n');
   const headers = lines[0].split(',').map(h => h.trim().replace(/\r/g,''));
@@ -261,7 +175,6 @@ function parseCSV(text) {
     return obj;
   }).filter(r => Object.values(r).some(v => v !== ''));
 }
-
 async function loadAll() {
   await Promise.all(Object.entries(FILES).map(async ([key, url]) => {
     try {
@@ -272,20 +185,17 @@ async function loadAll() {
   }));
   processData();
 }
-
 function n(v, dec=1) { const f = parseFloat(v); return isNaN(f) ? '—' : f.toFixed(dec); }
 function pct(v) { const f = parseFloat(v); return isNaN(f) ? '—' : (f * 100).toFixed(1) + '%'; }
 function wrClass(v) { const f = parseFloat(v); if (isNaN(f)) return ''; return f >= 0.60 ? 'wr-high' : f >= 0.50 ? 'wr-mid' : 'wr-low'; }
 function roiColor(v) { const f = parseFloat(v); if (isNaN(f)) return ''; return f >= 0 ? 'win' : 'loss'; }
-
 function showSection(name, el) {
   document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
-  document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
+  document.querySelectorAll('.dash-tabs a').forEach(a => a.classList.remove('active'));
   document.getElementById('sec-' + name).classList.add('active');
   if (el) el.classList.add('active');
   if (name === 'date' && D['nba_summary_by_date']) renderDateChart();
 }
-
 function processData() {
   const overall = D['nba_summary_overall'];
   if (overall && overall[0]) {
@@ -306,34 +216,27 @@ function processData() {
   } else {
     document.getElementById('last-updated').textContent = 'NO DATA';
   }
-
   renderSummaryTable('nba_summary_by_market',     'load-market', ['market_type','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
   renderSummaryTable('nba_summary_by_side_group', 'load-side',   ['side_group','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
   renderSummaryTable('nba_summary_by_date',       'load-date',   ['game_date','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
-
   renderSummaryTable('nba_moneyline_by_edge', 'load-edge-ml',  ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nba_spread_by_edge',    'load-edge-sp',  ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nba_total_by_edge',     'load-edge-tot', ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
-
   renderSummaryTable('nba_moneyline_by_odds', 'load-odds-ml',  ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nba_spread_by_odds',    'load-odds-sp',  ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nba_total_by_odds',     'load-odds-tot', ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
-
   renderSummaryTable('nba_moneyline_by_kelly', 'load-kelly-ml',  ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nba_spread_by_kelly',    'load-kelly-sp',  ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nba_total_by_kelly',     'load-kelly-tot', ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
-
   if (D['nba_bet_log']) { betLogFiltered = D['nba_bet_log']; renderBetLog(); }
   if (D['nba_summary_by_market']) renderTally();
   if (D['nba_summary_by_date']) renderDateChart();
 }
-
 function renderSummaryTable(key, targetId, cols) {
   const el = document.getElementById(targetId);
   if (!el) return;
   const data = D[key];
   if (!data || !data.length) { el.textContent = 'No data: ' + key; return; }
-
   const headers = cols.map(c => `<th onclick="sortTable(this)">${c.replace(/_/g,' ').toUpperCase()}</th>`).join('');
   const rows = data.map(r => {
     const cells = cols.map(c => {
@@ -348,10 +251,8 @@ function renderSummaryTable(key, targetId, cols) {
     }).join('');
     return `<tr>${cells}</tr>`;
   }).join('');
-
   el.outerHTML = `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
 }
-
 function renderTally() {
   const data = D['nba_summary_by_market'];
   if (!data || !data.length) return;
@@ -369,7 +270,6 @@ function renderTally() {
   document.getElementById('tally-chart').innerHTML = `<div class="section-title" style="font-size:1rem;margin-bottom:20px">WIN RATE BY MARKET</div>${bars}`;
   renderSummaryTable('nba_summary_by_market', 'load-tally-table', ['market_type','wins','losses','bets','win_rate','units','roi']);
 }
-
 function renderBetLog() {
   const wrap = document.getElementById('betlog-wrap');
   const data = betLogFiltered;
@@ -393,7 +293,6 @@ function renderBetLog() {
   wrap.innerHTML = `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
   renderPages(data.length);
 }
-
 function filterBetLog(q) {
   const all = D['nba_bet_log'] || [];
   const lower = q.toLowerCase();
@@ -401,7 +300,6 @@ function filterBetLog(q) {
   betLogPage = 0;
   renderBetLog();
 }
-
 function renderPages(total) {
   const pages = Math.ceil(total / PAGE_SIZE);
   const container = document.getElementById('betlog-pages');
@@ -415,7 +313,6 @@ function renderPages(total) {
     container.appendChild(btn);
   }
 }
-
 function renderDateChart() {
   const data = D['nba_summary_by_date'];
   if (!data || !data.length) return;
@@ -459,13 +356,12 @@ function renderDateChart() {
     ctx.stroke();
     wrs.forEach((v, i) => { ctx.fillStyle = '#ff6b35'; ctx.beginPath(); ctx.arc(xPos(i), yPosWR(v), 3, 0, Math.PI*2); ctx.fill(); });
   }
-  ctx.fillStyle = 'rgba(138,155,184,0.7)'; ctx.font = '9px DM Mono, monospace'; ctx.textAlign = 'center';
+  ctx.fillStyle = 'rgba(124,135,150,0.7)'; ctx.font = '9px monospace'; ctx.textAlign = 'center';
   const step = Math.ceil(nd / 10);
   dates.forEach((d, i) => { if (i % step === 0) ctx.fillText(d.replace('2026_','').replace(/_/g,'/'), xPos(i), H-PAD.bottom+18); });
   ctx.textAlign = 'right';
   for (let i = 0; i <= 4; i++) { const v = 100-(100/4)*i; ctx.fillText(v.toFixed(0)+'%', PAD.left-8, PAD.top+(chartH/4)*i+4); }
 }
-
 function sortTable(th) {
   const tbody = th.closest('table').querySelector('tbody');
   const rows = Array.from(tbody.querySelectorAll('tr'));
@@ -480,11 +376,8 @@ function sortTable(th) {
   });
   rows.forEach(r => tbody.appendChild(r));
 }
-
 window.addEventListener('resize', () => { if (D['nba_summary_by_date']) renderDateChart(); });
-
 loadAll();
 </script>
-
 </body>
 </html>

--- a/docs/ncaab_dashboard.html
+++ b/docs/ncaab_dashboard.html
@@ -1,90 +1,15 @@
 <!DOCTYPE html>
-
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NCAAB Betting Dashboard</title>
-<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Mono:wght@300;400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
-<style>
-  :root {
-    --bg: #0a0c10;
-    --bg2: #0f1218;
-    --bg3: #141820;
-    --border: #1e2530;
-    --border2: #252e3d;
-    --accent: #a855f7;
-    --green: #00e676;
-    --red: #ff3d5a;
-    --gold: #ffd600;
-    --text: #e8edf5;
-    --text2: #8a9bb8;
-    --text3: #4a5568;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { background: var(--bg); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 14px; min-height: 100vh; }
-  header { background: linear-gradient(135deg, #0a0c10 0%, #0f0a1a 100%); border-bottom: 1px solid var(--border); padding: 24px 32px; display: flex; align-items: center; justify-content: space-between; position: sticky; top: 0; z-index: 100; backdrop-filter: blur(12px); }
-  header h1 { font-family: 'Bebas Neue', sans-serif; font-size: 2.4rem; letter-spacing: 4px; background: linear-gradient(90deg, #a855f7, #ffffff); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-  .header-sub { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--text2); letter-spacing: 2px; text-transform: uppercase; margin-top: 2px; }
-  .status-pill { background: rgba(0,230,118,0.1); border: 1px solid rgba(0,230,118,0.3); color: var(--green); font-family: 'DM Mono', monospace; font-size: 11px; padding: 6px 14px; border-radius: 100px; letter-spacing: 1px; }
-  nav { background: var(--bg2); border-bottom: 1px solid var(--border); padding: 0 32px; display: flex; gap: 0; overflow-x: auto; }
-  nav a { color: var(--text2); text-decoration: none; font-size: 12px; font-weight: 500; letter-spacing: 1px; text-transform: uppercase; padding: 14px 20px; border-bottom: 2px solid transparent; transition: all 0.2s; white-space: nowrap; cursor: pointer; }
-  nav a:hover, nav a.active { color: var(--accent); border-bottom-color: var(--accent); }
-  main { padding: 32px; max-width: 1400px; margin: 0 auto; }
-  .section { display: none; }
-  .section.active { display: block; }
-  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 16px; margin-bottom: 32px; }
-  .stat-card { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; padding: 20px; position: relative; overflow: hidden; transition: border-color 0.2s; }
-  .stat-card:hover { border-color: var(--border2); }
-  .stat-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px; background: var(--accent); opacity: 0.6; }
-  .stat-card.green::before { background: var(--green); }
-  .stat-card.red::before { background: var(--red); }
-  .stat-card.gold::before { background: var(--gold); }
-  .stat-label { font-family: 'DM Mono', monospace; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--text3); margin-bottom: 10px; }
-  .stat-value { font-family: 'Bebas Neue', sans-serif; font-size: 2rem; letter-spacing: 1px; line-height: 1; }
-  .stat-value.green { color: var(--green); }
-  .stat-value.red { color: var(--red); }
-  .stat-value.gold { color: var(--gold); }
-  .stat-value.accent { color: var(--accent); }
-  .section-title { font-family: 'Bebas Neue', sans-serif; font-size: 1.4rem; letter-spacing: 3px; color: var(--text2); margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 12px; }
-  .section-title span { width: 3px; height: 20px; background: var(--accent); border-radius: 2px; display: inline-block; }
-  .table-wrap { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin-bottom: 28px; }
-  table { width: 100%; border-collapse: collapse; font-family: 'DM Mono', monospace; font-size: 12px; }
-  thead tr { background: rgba(168,85,247,0.05); border-bottom: 1px solid var(--border); }
-  th { text-align: left; padding: 12px 16px; font-size: 10px; letter-spacing: 2px; text-transform: uppercase; color: var(--text3); font-weight: 500; cursor: pointer; user-select: none; white-space: nowrap; }
-  th:hover { color: var(--accent); }
-  td { padding: 11px 16px; border-bottom: 1px solid rgba(30,37,48,0.6); white-space: nowrap; }
-  tr:last-child td { border-bottom: none; }
-  tbody tr:hover { background: rgba(255,255,255,0.02); }
-  .win { color: var(--green); }
-  .loss { color: var(--red); }
-  .push { color: var(--gold); }
-  .bar-chart { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin-bottom: 28px; }
-  .bar-row { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
-  .bar-label { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--text2); width: 140px; text-align: right; flex-shrink: 0; }
-  .bar-track { flex: 1; height: 28px; background: rgba(255,255,255,0.04); border-radius: 4px; overflow: hidden; }
-  .bar-fill { height: 100%; border-radius: 4px; display: flex; align-items: center; padding-left: 10px; font-family: 'DM Mono', monospace; font-size: 11px; font-weight: 500; transition: width 0.8s cubic-bezier(0.4,0,0.2,1); }
-  .bar-fill.win-bar { background: linear-gradient(90deg, rgba(0,230,118,0.4), rgba(0,230,118,0.15)); color: var(--green); }
-  .bar-fill.loss-bar { background: linear-gradient(90deg, rgba(255,61,90,0.4), rgba(255,61,90,0.15)); color: var(--red); }
-  .bar-fill.neutral-bar { background: linear-gradient(90deg, rgba(168,85,247,0.4), rgba(168,85,247,0.15)); color: var(--accent); }
-  .bar-meta { font-family: 'DM Mono', monospace; font-size: 11px; color: var(--text2); width: 60px; flex-shrink: 0; }
-  .date-chart { background: var(--bg3); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin-bottom: 28px; }
-  canvas { width: 100% !important; }
-  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 28px; }
-  @media (max-width: 900px) { .grid-2 { grid-template-columns: 1fr; } }
-  .search-bar { width: 100%; background: var(--bg3); border: 1px solid var(--border); border-radius: 8px; padding: 10px 16px; color: var(--text); font-family: 'DM Mono', monospace; font-size: 12px; margin-bottom: 16px; outline: none; transition: border-color 0.2s; }
-  .search-bar:focus { border-color: var(--accent); }
-  .pagination { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; flex-wrap: wrap; }
-  .page-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--text2); font-family: 'DM Mono', monospace; font-size: 11px; padding: 6px 12px; border-radius: 6px; cursor: pointer; transition: all 0.2s; }
-  .page-btn:hover, .page-btn.active { background: var(--accent); color: #000; border-color: var(--accent); }
-  .loading { text-align: center; padding: 60px; font-family: 'DM Mono', monospace; font-size: 12px; color: var(--text3); letter-spacing: 2px; }
-  .wr-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
-  .wr-high { background: rgba(0,230,118,0.15); color: var(--green); }
-  .wr-mid  { background: rgba(255,214,0,0.15);  color: var(--gold); }
-  .wr-low  { background: rgba(255,61,90,0.15);  color: var(--red); }
-</style>
+<title>NCAAB Analytics | EDGELYTICS</title>
+<link rel="stylesheet" href="css/matstheme.css">
+<link rel="stylesheet" href="css/dashboard.css">
+<style>:root { --sport-accent: #a855f7; }</style>
 </head>
 <body>
+<div id="nav-placeholder"></div>
 
 <header>
   <div>
@@ -94,7 +19,7 @@
   <div class="status-pill" id="last-updated">LOADING...</div>
 </header>
 
-<nav>
+<div class="dash-tabs">
   <a class="active" onclick="showSection('market', this)">Market</a>
   <a onclick="showSection('side', this)">Side</a>
   <a onclick="showSection('edge', this)">Edge</a>
@@ -103,10 +28,9 @@
   <a onclick="showSection('date', this)">By Date</a>
   <a onclick="showSection('betlog', this)">Bet Log</a>
   <a onclick="showSection('tally', this)">Tally</a>
-</nav>
+</div>
 
 <main>
-
   <div class="stat-grid" id="stat-cards" style="display:none">
     <div class="stat-card accent">
       <div class="stat-label">Total Bets</div>
@@ -146,12 +70,10 @@
     <div class="section-title"><span></span>BY MARKET</div>
     <div class="table-wrap"><div class="loading" id="load-market">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-side">
     <div class="section-title"><span></span>BY SIDE</div>
     <div class="table-wrap"><div class="loading" id="load-side">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-edge">
     <div class="section-title"><span></span>BY EDGE BUCKET</div>
     <div class="grid-2">
@@ -167,7 +89,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-edge-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-odds">
     <div class="section-title"><span></span>BY ODDS BUCKET</div>
     <div class="grid-2">
@@ -183,7 +104,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-odds-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-kelly">
     <div class="section-title"><span></span>BY KELLY BUCKET</div>
     <div class="grid-2">
@@ -199,7 +119,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-kelly-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-date">
     <div class="section-title"><span></span>PERFORMANCE BY DATE</div>
     <div class="date-chart">
@@ -207,25 +126,22 @@
     </div>
     <div class="table-wrap"><div class="loading" id="load-date">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-betlog">
     <div class="section-title"><span></span>BET LOG</div>
     <input type="text" class="search-bar" placeholder="Search teams, market, result..." oninput="filterBetLog(this.value)">
     <div class="table-wrap" id="betlog-wrap"><div class="loading">Loading...</div></div>
     <div class="pagination" id="betlog-pages"></div>
   </div>
-
   <div class="section" id="sec-tally">
     <div class="section-title"><span></span>MARKET TALLY</div>
     <div class="bar-chart" id="tally-chart"><div class="loading">Loading...</div></div>
     <div class="table-wrap"><div class="loading" id="load-tally-table">Loading...</div></div>
   </div>
-
 </main>
 
+<script src="js/nav.js"></script>
 <script>
 const BASE = 'https://raw.githubusercontent.com/Clownworldenjoyer76/bet_tracker/main/docs/win/final_scores/deeper_summaries/ncaab/';
-
 const FILES = {
   ncaab_summary_overall:            BASE + 'ncaab_summary_overall.csv',
   ncaab_summary_by_market:          BASE + 'ncaab_summary_by_market.csv',
@@ -245,12 +161,10 @@ const FILES = {
   ncaab_total_by_odds:              BASE + 'by_market/ncaab_total_by_odds.csv',
   ncaab_total_by_side:              BASE + 'by_market/ncaab_total_by_side.csv',
 };
-
 const D = {};
 let betLogFiltered = [];
 let betLogPage = 0;
 const PAGE_SIZE = 50;
-
 function parseCSV(text) {
   const lines = text.trim().split('\n');
   const headers = lines[0].split(',').map(h => h.trim().replace(/\r/g,''));
@@ -261,7 +175,6 @@ function parseCSV(text) {
     return obj;
   }).filter(r => Object.values(r).some(v => v !== ''));
 }
-
 async function loadAll() {
   await Promise.all(Object.entries(FILES).map(async ([key, url]) => {
     try {
@@ -272,20 +185,17 @@ async function loadAll() {
   }));
   processData();
 }
-
 function n(v, dec=1) { const f = parseFloat(v); return isNaN(f) ? '—' : f.toFixed(dec); }
 function pct(v) { const f = parseFloat(v); return isNaN(f) ? '—' : (f * 100).toFixed(1) + '%'; }
 function wrClass(v) { const f = parseFloat(v); if (isNaN(f)) return ''; return f >= 0.60 ? 'wr-high' : f >= 0.50 ? 'wr-mid' : 'wr-low'; }
 function roiColor(v) { const f = parseFloat(v); if (isNaN(f)) return ''; return f >= 0 ? 'win' : 'loss'; }
-
 function showSection(name, el) {
   document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
-  document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
+  document.querySelectorAll('.dash-tabs a').forEach(a => a.classList.remove('active'));
   document.getElementById('sec-' + name).classList.add('active');
   if (el) el.classList.add('active');
   if (name === 'date' && D['ncaab_summary_by_date']) renderDateChart();
 }
-
 function processData() {
   const overall = D['ncaab_summary_overall'];
   if (overall && overall[0]) {
@@ -306,34 +216,27 @@ function processData() {
   } else {
     document.getElementById('last-updated').textContent = 'NO DATA';
   }
-
   renderSummaryTable('ncaab_summary_by_market',     'load-market', ['market_type','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
   renderSummaryTable('ncaab_summary_by_side_group', 'load-side',   ['side_group','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
   renderSummaryTable('ncaab_summary_by_date',       'load-date',   ['game_date','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
-
   renderSummaryTable('ncaab_moneyline_by_edge', 'load-edge-ml',  ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('ncaab_spread_by_edge',    'load-edge-sp',  ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('ncaab_total_by_edge',     'load-edge-tot', ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
-
   renderSummaryTable('ncaab_moneyline_by_odds', 'load-odds-ml',  ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('ncaab_spread_by_odds',    'load-odds-sp',  ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('ncaab_total_by_odds',     'load-odds-tot', ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
-
   renderSummaryTable('ncaab_moneyline_by_kelly', 'load-kelly-ml',  ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('ncaab_spread_by_kelly',    'load-kelly-sp',  ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('ncaab_total_by_kelly',     'load-kelly-tot', ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
-
   if (D['ncaab_bet_log']) { betLogFiltered = D['ncaab_bet_log']; renderBetLog(); }
   if (D['ncaab_summary_by_market']) renderTally();
   if (D['ncaab_summary_by_date']) renderDateChart();
 }
-
 function renderSummaryTable(key, targetId, cols) {
   const el = document.getElementById(targetId);
   if (!el) return;
   const data = D[key];
   if (!data || !data.length) { el.textContent = 'No data: ' + key; return; }
-
   const headers = cols.map(c => `<th onclick="sortTable(this)">${c.replace(/_/g,' ').toUpperCase()}</th>`).join('');
   const rows = data.map(r => {
     const cells = cols.map(c => {
@@ -348,10 +251,8 @@ function renderSummaryTable(key, targetId, cols) {
     }).join('');
     return `<tr>${cells}</tr>`;
   }).join('');
-
   el.outerHTML = `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
 }
-
 function renderTally() {
   const data = D['ncaab_summary_by_market'];
   if (!data || !data.length) return;
@@ -369,7 +270,6 @@ function renderTally() {
   document.getElementById('tally-chart').innerHTML = `<div class="section-title" style="font-size:1rem;margin-bottom:20px">WIN RATE BY MARKET</div>${bars}`;
   renderSummaryTable('ncaab_summary_by_market', 'load-tally-table', ['market_type','wins','losses','bets','win_rate','units','roi']);
 }
-
 function renderBetLog() {
   const wrap = document.getElementById('betlog-wrap');
   const data = betLogFiltered;
@@ -393,7 +293,6 @@ function renderBetLog() {
   wrap.innerHTML = `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
   renderPages(data.length);
 }
-
 function filterBetLog(q) {
   const all = D['ncaab_bet_log'] || [];
   const lower = q.toLowerCase();
@@ -401,7 +300,6 @@ function filterBetLog(q) {
   betLogPage = 0;
   renderBetLog();
 }
-
 function renderPages(total) {
   const pages = Math.ceil(total / PAGE_SIZE);
   const container = document.getElementById('betlog-pages');
@@ -415,7 +313,6 @@ function renderPages(total) {
     container.appendChild(btn);
   }
 }
-
 function renderDateChart() {
   const data = D['ncaab_summary_by_date'];
   if (!data || !data.length) return;
@@ -459,13 +356,12 @@ function renderDateChart() {
     ctx.stroke();
     wrs.forEach((v, i) => { ctx.fillStyle = '#a855f7'; ctx.beginPath(); ctx.arc(xPos(i), yPosWR(v), 3, 0, Math.PI*2); ctx.fill(); });
   }
-  ctx.fillStyle = 'rgba(138,155,184,0.7)'; ctx.font = '9px DM Mono, monospace'; ctx.textAlign = 'center';
+  ctx.fillStyle = 'rgba(124,135,150,0.7)'; ctx.font = '9px monospace'; ctx.textAlign = 'center';
   const step = Math.ceil(nd / 10);
   dates.forEach((d, i) => { if (i % step === 0) ctx.fillText(d.replace('2026_','').replace(/_/g,'/'), xPos(i), H-PAD.bottom+18); });
   ctx.textAlign = 'right';
   for (let i = 0; i <= 4; i++) { const v = 100-(100/4)*i; ctx.fillText(v.toFixed(0)+'%', PAD.left-8, PAD.top+(chartH/4)*i+4); }
 }
-
 function sortTable(th) {
   const tbody = th.closest('table').querySelector('tbody');
   const rows = Array.from(tbody.querySelectorAll('tr'));
@@ -480,11 +376,8 @@ function sortTable(th) {
   });
   rows.forEach(r => tbody.appendChild(r));
 }
-
 window.addEventListener('resize', () => { if (D['ncaab_summary_by_date']) renderDateChart(); });
-
 loadAll();
 </script>
-
 </body>
 </html>

--- a/docs/nhl_dashboard.html
+++ b/docs/nhl_dashboard.html
@@ -3,368 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Mat's NHL Betting Dashboard</title>
-<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Mono:wght@300;400;500&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
-<style>
-  :root {
-    --bg: #0a0c10;
-    --bg2: #0f1218;
-    --bg3: #141820;
-    --border: #1e2530;
-    --border2: #252e3d;
-    --accent: #00d4ff;
-    --accent2: #0099cc;
-    --green: #00e676;
-    --red: #ff3d5a;
-    --gold: #ffd600;
-    --text: #e8edf5;
-    --text2: #8a9bb8;
-    --text3: #4a5568;
-    --card-shadow: 0 4px 24px rgba(0,0,0,0.4);
-  }
-
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family: 'DM Sans', sans-serif;
-    font-size: 14px;
-    min-height: 100vh;
-  }
-
-  header {
-    background: linear-gradient(135deg, #0a0c10 0%, #0f1a2e 100%);
-    border-bottom: 1px solid var(--border);
-    padding: 24px 32px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    backdrop-filter: blur(12px);
-  }
-
-  header h1 {
-    font-family: 'Bebas Neue', sans-serif;
-    font-size: 2.4rem;
-    letter-spacing: 4px;
-    background: linear-gradient(90deg, #00d4ff, #ffffff);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-
-  .header-sub {
-    font-family: 'DM Mono', monospace;
-    font-size: 11px;
-    color: var(--text2);
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    margin-top: 2px;
-  }
-
-  .status-pill {
-    background: rgba(0,230,118,0.1);
-    border: 1px solid rgba(0,230,118,0.3);
-    color: var(--green);
-    font-family: 'DM Mono', monospace;
-    font-size: 11px;
-    padding: 6px 14px;
-    border-radius: 100px;
-    letter-spacing: 1px;
-  }
-
-  nav {
-    background: var(--bg2);
-    border-bottom: 1px solid var(--border);
-    padding: 0 32px;
-    display: flex;
-    gap: 0;
-    overflow-x: auto;
-  }
-
-  nav a {
-    color: var(--text2);
-    text-decoration: none;
-    font-size: 12px;
-    font-weight: 500;
-    letter-spacing: 1px;
-    text-transform: uppercase;
-    padding: 14px 20px;
-    border-bottom: 2px solid transparent;
-    transition: all 0.2s;
-    white-space: nowrap;
-    cursor: pointer;
-  }
-
-  nav a:hover, nav a.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
-  }
-
-  main { padding: 32px; max-width: 1400px; margin: 0 auto; }
-
-  .section { display: none; }
-  .section.active { display: block; }
-
-  .stat-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 16px;
-    margin-bottom: 32px;
-  }
-
-  .stat-card {
-    background: var(--bg3);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 20px;
-    position: relative;
-    overflow: hidden;
-    transition: border-color 0.2s;
-  }
-
-  .stat-card:hover { border-color: var(--border2); }
-
-  .stat-card::before {
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0;
-    height: 2px;
-    background: var(--accent);
-    opacity: 0.6;
-  }
-
-  .stat-card.green::before { background: var(--green); }
-  .stat-card.red::before { background: var(--red); }
-  .stat-card.gold::before { background: var(--gold); }
-
-  .stat-label {
-    font-family: 'DM Mono', monospace;
-    font-size: 10px;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    color: var(--text3);
-    margin-bottom: 10px;
-  }
-
-  .stat-value {
-    font-family: 'Bebas Neue', sans-serif;
-    font-size: 2rem;
-    letter-spacing: 1px;
-    line-height: 1;
-  }
-
-  .stat-value.green { color: var(--green); }
-  .stat-value.red { color: var(--red); }
-  .stat-value.gold { color: var(--gold); }
-  .stat-value.accent { color: var(--accent); }
-
-  .section-title {
-    font-family: 'Bebas Neue', sans-serif;
-    font-size: 1.4rem;
-    letter-spacing: 3px;
-    color: var(--text2);
-    margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .section-title span {
-    width: 3px;
-    height: 20px;
-    background: var(--accent);
-    border-radius: 2px;
-    display: inline-block;
-  }
-
-  .table-wrap {
-    background: var(--bg3);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    overflow: hidden;
-    margin-bottom: 28px;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    font-family: 'DM Mono', monospace;
-    font-size: 12px;
-  }
-
-  thead tr {
-    background: rgba(0,212,255,0.05);
-    border-bottom: 1px solid var(--border);
-  }
-
-  th {
-    text-align: left;
-    padding: 12px 16px;
-    font-size: 10px;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    color: var(--text3);
-    font-weight: 500;
-    cursor: pointer;
-    user-select: none;
-    white-space: nowrap;
-  }
-
-  th:hover { color: var(--accent); }
-
-  td {
-    padding: 11px 16px;
-    border-bottom: 1px solid rgba(30,37,48,0.6);
-    white-space: nowrap;
-  }
-
-  tr:last-child td { border-bottom: none; }
-  tbody tr:hover { background: rgba(255,255,255,0.02); }
-
-  .win { color: var(--green); }
-  .loss { color: var(--red); }
-  .push { color: var(--gold); }
-
-  .bar-chart {
-    background: var(--bg3);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 28px;
-  }
-
-  .bar-row {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 14px;
-  }
-
-  .bar-label {
-    font-family: 'DM Mono', monospace;
-    font-size: 11px;
-    color: var(--text2);
-    width: 140px;
-    text-align: right;
-    flex-shrink: 0;
-  }
-
-  .bar-track {
-    flex: 1;
-    height: 28px;
-    background: rgba(255,255,255,0.04);
-    border-radius: 4px;
-    overflow: hidden;
-  }
-
-  .bar-fill {
-    height: 100%;
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    padding-left: 10px;
-    font-family: 'DM Mono', monospace;
-    font-size: 11px;
-    font-weight: 500;
-    transition: width 0.8s cubic-bezier(0.4,0,0.2,1);
-  }
-
-  .bar-fill.win-bar { background: linear-gradient(90deg, rgba(0,230,118,0.4), rgba(0,230,118,0.15)); color: var(--green); }
-  .bar-fill.loss-bar { background: linear-gradient(90deg, rgba(255,61,90,0.4), rgba(255,61,90,0.15)); color: var(--red); }
-  .bar-fill.neutral-bar { background: linear-gradient(90deg, rgba(0,212,255,0.4), rgba(0,212,255,0.15)); color: var(--accent); }
-
-  .bar-meta {
-    font-family: 'DM Mono', monospace;
-    font-size: 11px;
-    color: var(--text2);
-    width: 60px;
-    flex-shrink: 0;
-  }
-
-  .date-chart {
-    background: var(--bg3);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 24px;
-    margin-bottom: 28px;
-  }
-
-  canvas { width: 100% !important; }
-
-  .grid-2 {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
-    margin-bottom: 28px;
-  }
-
-  @media (max-width: 900px) { .grid-2 { grid-template-columns: 1fr; } }
-
-  .search-bar {
-    width: 100%;
-    background: var(--bg3);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 10px 16px;
-    color: var(--text);
-    font-family: 'DM Mono', monospace;
-    font-size: 12px;
-    margin-bottom: 16px;
-    outline: none;
-    transition: border-color 0.2s;
-  }
-
-  .search-bar:focus { border-color: var(--accent); }
-
-  .pagination {
-    display: flex;
-    gap: 8px;
-    justify-content: flex-end;
-    margin-top: 12px;
-    flex-wrap: wrap;
-  }
-
-  .page-btn {
-    background: var(--bg3);
-    border: 1px solid var(--border);
-    color: var(--text2);
-    font-family: 'DM Mono', monospace;
-    font-size: 11px;
-    padding: 6px 12px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .page-btn:hover, .page-btn.active { background: var(--accent); color: #000; border-color: var(--accent); }
-
-  .loading {
-    text-align: center;
-    padding: 60px;
-    font-family: 'DM Mono', monospace;
-    font-size: 12px;
-    color: var(--text3);
-    letter-spacing: 2px;
-  }
-
-  .wr-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 600;
-  }
-  .wr-high { background: rgba(0,230,118,0.15); color: var(--green); }
-  .wr-mid  { background: rgba(255,214,0,0.15);  color: var(--gold); }
-  .wr-low  { background: rgba(255,61,90,0.15);  color: var(--red); }
-</style>
+<title>NHL Analytics | EDGELYTICS</title>
+<link rel="stylesheet" href="css/matstheme.css">
+<link rel="stylesheet" href="css/dashboard.css">
+<style>:root { --sport-accent: var(--accent-blue); }</style>
 </head>
 <body>
+<div id="nav-placeholder"></div>
 
 <header>
   <div>
@@ -374,7 +19,7 @@
   <div class="status-pill" id="last-updated">LOADING...</div>
 </header>
 
-<nav>
+<div class="dash-tabs">
   <a class="active" onclick="showSection('market', this)">Market</a>
   <a onclick="showSection('side', this)">Side</a>
   <a onclick="showSection('edge', this)">Edge</a>
@@ -383,10 +28,9 @@
   <a onclick="showSection('date', this)">By Date</a>
   <a onclick="showSection('betlog', this)">Bet Log</a>
   <a onclick="showSection('tally', this)">Tally</a>
-</nav>
+</div>
 
 <main>
-
   <div class="stat-grid" id="stat-cards" style="display:none">
     <div class="stat-card accent">
       <div class="stat-label">Total Bets</div>
@@ -426,12 +70,10 @@
     <div class="section-title"><span></span>BY MARKET</div>
     <div class="table-wrap"><div class="loading" id="load-market">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-side">
     <div class="section-title"><span></span>BY SIDE</div>
     <div class="table-wrap"><div class="loading" id="load-side">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-edge">
     <div class="section-title"><span></span>BY EDGE BUCKET</div>
     <div class="grid-2">
@@ -447,7 +89,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-edge-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-odds">
     <div class="section-title"><span></span>BY ODDS BUCKET</div>
     <div class="grid-2">
@@ -463,7 +104,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-odds-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-kelly">
     <div class="section-title"><span></span>BY KELLY BUCKET</div>
     <div class="grid-2">
@@ -479,7 +119,6 @@
     <div class="section-title" style="font-size:1rem">TOTAL</div>
     <div class="table-wrap"><div class="loading" id="load-kelly-tot">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-date">
     <div class="section-title"><span></span>PERFORMANCE BY DATE</div>
     <div class="date-chart">
@@ -487,25 +126,22 @@
     </div>
     <div class="table-wrap"><div class="loading" id="load-date">Loading...</div></div>
   </div>
-
   <div class="section" id="sec-betlog">
     <div class="section-title"><span></span>BET LOG</div>
     <input type="text" class="search-bar" placeholder="Search teams, market, result..." oninput="filterBetLog(this.value)">
     <div class="table-wrap" id="betlog-wrap"><div class="loading">Loading...</div></div>
     <div class="pagination" id="betlog-pages"></div>
   </div>
-
   <div class="section" id="sec-tally">
     <div class="section-title"><span></span>MARKET TALLY</div>
     <div class="bar-chart" id="tally-chart"><div class="loading">Loading...</div></div>
     <div class="table-wrap"><div class="loading" id="load-tally-table">Loading...</div></div>
   </div>
-
 </main>
 
+<script src="js/nav.js"></script>
 <script>
 const BASE = 'https://raw.githubusercontent.com/Clownworldenjoyer76/bet_tracker/main/docs/win/final_scores/deeper_summaries/nhl/';
-
 const FILES = {
   nhl_summary_overall:          BASE + 'nhl_summary_overall.csv',
   nhl_summary_by_market:        BASE + 'nhl_summary_by_market.csv',
@@ -529,12 +165,10 @@ const FILES = {
   nhl_total_by_odds:            BASE + 'by_market/nhl_total_by_odds.csv',
   nhl_total_by_side:            BASE + 'by_market/nhl_total_by_side.csv',
 };
-
 const D = {};
 let betLogFiltered = [];
 let betLogPage = 0;
 const PAGE_SIZE = 50;
-
 function parseCSV(text) {
   const lines = text.trim().split('\n');
   const headers = lines[0].split(',').map(h => h.trim().replace(/\r/g,''));
@@ -545,52 +179,27 @@ function parseCSV(text) {
     return obj;
   }).filter(r => Object.values(r).some(v => v !== ''));
 }
-
 async function loadAll() {
-  const entries = Object.entries(FILES);
-  await Promise.all(entries.map(async ([key, url]) => {
+  await Promise.all(Object.entries(FILES).map(async ([key, url]) => {
     try {
       const res = await fetch(url);
       if (!res.ok) return;
-      const text = await res.text();
-      D[key] = parseCSV(text);
+      D[key] = parseCSV(await res.text());
     } catch(e) {}
   }));
   processData();
 }
-
-function n(v, dec=1) {
-  const f = parseFloat(v);
-  return isNaN(f) ? '—' : f.toFixed(dec);
-}
-
-function pct(v) {
-  const f = parseFloat(v);
-  return isNaN(f) ? '—' : (f * 100).toFixed(1) + '%';
-}
-
-function wrClass(v) {
-  const f = parseFloat(v);
-  if (isNaN(f)) return '';
-  if (f >= 0.60) return 'wr-high';
-  if (f >= 0.50) return 'wr-mid';
-  return 'wr-low';
-}
-
-function roiColor(v) {
-  const f = parseFloat(v);
-  if (isNaN(f)) return '';
-  return f >= 0 ? 'win' : 'loss';
-}
-
+function n(v, dec=1) { const f = parseFloat(v); return isNaN(f) ? '—' : f.toFixed(dec); }
+function pct(v) { const f = parseFloat(v); return isNaN(f) ? '—' : (f * 100).toFixed(1) + '%'; }
+function wrClass(v) { const f = parseFloat(v); if (isNaN(f)) return ''; if (f >= 0.60) return 'wr-high'; if (f >= 0.50) return 'wr-mid'; return 'wr-low'; }
+function roiColor(v) { const f = parseFloat(v); if (isNaN(f)) return ''; return f >= 0 ? 'win' : 'loss'; }
 function showSection(name, el) {
   document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
-  document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
+  document.querySelectorAll('.dash-tabs a').forEach(a => a.classList.remove('active'));
   document.getElementById('sec-' + name).classList.add('active');
   if (el) el.classList.add('active');
   if (name === 'date' && D['nhl_summary_by_date']) renderDateChart();
 }
-
 function processData() {
   const overall = D['nhl_summary_overall'];
   if (overall && overall[0]) {
@@ -611,46 +220,33 @@ function processData() {
   } else {
     document.getElementById('last-updated').textContent = 'NO DATA';
   }
-
   renderSummaryTable('nhl_summary_by_market',    'load-market', ['market_type','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
   renderSummaryTable('nhl_summary_by_side_group','load-side',   ['side_group','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
   renderSummaryTable('nhl_summary_by_date',      'load-date',   ['game_date','bets','wins','losses','win_rate','units','roi','avg_edge','avg_odds']);
-
   renderSummaryTable('nhl_moneyline_by_edge', 'load-edge-ml',  ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nhl_puck_line_by_edge', 'load-edge-pl',  ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nhl_total_by_edge',     'load-edge-tot', ['edge_bucket','bets','wins','losses','win_rate','units','roi']);
-
   renderSummaryTable('nhl_moneyline_by_odds', 'load-odds-ml',  ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nhl_puck_line_by_odds', 'load-odds-pl',  ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nhl_total_by_odds',     'load-odds-tot', ['odds_bucket','bets','wins','losses','win_rate','units','roi']);
-
   renderSummaryTable('nhl_moneyline_by_kelly', 'load-kelly-ml',  ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nhl_puck_line_by_kelly', 'load-kelly-pl',  ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
   renderSummaryTable('nhl_total_by_kelly',     'load-kelly-tot', ['kelly_bucket','bets','wins','losses','win_rate','units','roi']);
-
   if (D['nhl_bet_log']) { betLogFiltered = D['nhl_bet_log']; renderBetLog(); }
   if (D['nhl_summary_by_market']) renderTally();
   if (D['nhl_summary_by_date']) renderDateChart();
 }
-
 function renderSummaryTable(key, targetId, cols) {
   const el = document.getElementById(targetId);
   if (!el) return;
   const data = D[key];
-  if (!data || !data.length) {
-    el.textContent = 'No data: ' + key;
-    return;
-  }
-
+  if (!data || !data.length) { el.textContent = 'No data: ' + key; return; }
   const headers = cols.map(c => `<th onclick="sortTable(this)">${c.replace(/_/g,' ').toUpperCase()}</th>`).join('');
   const rows = data.map(r => {
     const cells = cols.map(c => {
       if (c === 'win_rate') return `<td><span class="wr-badge ${wrClass(r[c])}">${pct(r[c])}</span></td>`;
       if (c === 'roi') return `<td class="${roiColor(r[c])}">${r[c] ? (parseFloat(r[c])*100).toFixed(1)+'%' : '—'}</td>`;
-      if (c === 'units') {
-        const u = parseFloat(r[c]);
-        return `<td class="${isNaN(u)?'':u>=0?'win':'loss'}">${isNaN(u)?'—':(u>=0?'+':'')+u.toFixed(2)}</td>`;
-      }
+      if (c === 'units') { const u = parseFloat(r[c]); return `<td class="${isNaN(u)?'':u>=0?'win':'loss'}">${isNaN(u)?'—':(u>=0?'+':'')+u.toFixed(2)}</td>`; }
       if (c === 'avg_edge') return `<td>${r[c] ? (parseFloat(r[c])*100).toFixed(2)+'%' : '—'}</td>`;
       if (c === 'avg_odds') return `<td>${r[c] ? (parseFloat(r[c])>0?'+':'')+n(r[c],0) : '—'}</td>`;
       if (c === 'wins') return `<td class="win">${r[c] || '—'}</td>`;
@@ -659,65 +255,49 @@ function renderSummaryTable(key, targetId, cols) {
     }).join('');
     return `<tr>${cells}</tr>`;
   }).join('');
-
   el.outerHTML = `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
 }
-
 function renderTally() {
   const data = D['nhl_summary_by_market'];
   if (!data || !data.length) return;
-
   const chartEl = document.getElementById('tally-chart');
   const maxBets = Math.max(...data.map(r => parseInt(r.bets) || 0));
-
   const bars = data.map(r => {
     const wr = parseFloat(r.win_rate) || 0;
     const w = Math.max(((parseInt(r.bets)||0) / maxBets) * 100, 2);
     const cls = wr >= 0.60 ? 'win-bar' : wr >= 0.50 ? 'neutral-bar' : 'loss-bar';
     return `<div class="bar-row">
       <div class="bar-label">${(r.market_type||'').toUpperCase()}</div>
-      <div class="bar-track">
-        <div class="bar-fill ${cls}" style="width:${w}%">${r.wins||0}W / ${r.losses||0}L</div>
-      </div>
+      <div class="bar-track"><div class="bar-fill ${cls}" style="width:${w}%">${r.wins||0}W / ${r.losses||0}L</div></div>
       <div class="bar-meta"><span class="wr-badge ${wrClass(r.win_rate)}">${pct(r.win_rate)}</span></div>
     </div>`;
   }).join('');
-
   chartEl.innerHTML = `<div class="section-title" style="font-size:1rem;margin-bottom:20px">WIN RATE BY MARKET</div>${bars}`;
-
   renderSummaryTable('nhl_summary_by_market', 'load-tally-table', ['market_type','wins','losses','bets','win_rate','units','roi']);
 }
-
 function renderBetLog() {
   const wrap = document.getElementById('betlog-wrap');
   const data = betLogFiltered;
   if (!data || !data.length) { wrap.innerHTML = '<div class="loading">No bet log data</div>'; return; }
-
   const start = betLogPage * PAGE_SIZE;
   const page = data.slice(start, start + PAGE_SIZE);
   const cols = ['game_date','away_team','home_team','market_type','bet_side','line','take_odds','selected_edge','bet_result','units'];
-
   const headers = cols.map(c => `<th>${c.replace(/_/g,' ').toUpperCase()}</th>`).join('');
   const rows = page.map(r => {
     const res = (r.bet_result||'').toLowerCase();
     const resClass = res === 'win' ? 'win' : res === 'loss' ? 'loss' : 'push';
     const cells = cols.map(c => {
       if (c === 'bet_result') return `<td class="${resClass}">${r[c] || '—'}</td>`;
-      if (c === 'units') {
-        const u = parseFloat(r[c]);
-        return `<td class="${isNaN(u)?'':u>=0?'win':'loss'}">${isNaN(u)?'—':(u>=0?'+':'')+u.toFixed(2)}</td>`;
-      }
+      if (c === 'units') { const u = parseFloat(r[c]); return `<td class="${isNaN(u)?'':u>=0?'win':'loss'}">${isNaN(u)?'—':(u>=0?'+':'')+u.toFixed(2)}</td>`; }
       if (c === 'selected_edge') return `<td>${r[c] ? (parseFloat(r[c])*100).toFixed(2)+'%' : '—'}</td>`;
       if (c === 'take_odds') return `<td>${r[c] ? (parseFloat(r[c])>0?'+':'')+r[c] : '—'}</td>`;
       return `<td>${r[c] || '—'}</td>`;
     }).join('');
     return `<tr>${cells}</tr>`;
   }).join('');
-
   wrap.innerHTML = `<table><thead><tr>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
   renderPages(data.length);
 }
-
 function filterBetLog(q) {
   const all = D['nhl_bet_log'] || [];
   const lower = q.toLowerCase();
@@ -725,7 +305,6 @@ function filterBetLog(q) {
   betLogPage = 0;
   renderBetLog();
 }
-
 function renderPages(total) {
   const pages = Math.ceil(total / PAGE_SIZE);
   const container = document.getElementById('betlog-pages');
@@ -739,112 +318,70 @@ function renderPages(total) {
     container.appendChild(btn);
   }
 }
-
 function renderDateChart() {
   const data = D['nhl_summary_by_date'];
   if (!data || !data.length) return;
   const canvas = document.getElementById('date-canvas');
   const ctx = canvas.getContext('2d');
-
   canvas.width = canvas.parentElement.offsetWidth - 48;
   canvas.height = 280;
-
   const dates = data.map(r => r.game_date || '');
   const wrs = data.map(r => (parseFloat(r.win_rate)||0)*100);
-
   const W = canvas.width, H = canvas.height;
   const PAD = { top: 20, right: 20, bottom: 50, left: 50 };
   const chartW = W - PAD.left - PAD.right;
   const chartH = H - PAD.top - PAD.bottom;
   const nd = dates.length;
-
   ctx.clearRect(0, 0, W, H);
-
-  ctx.strokeStyle = 'rgba(255,255,255,0.05)';
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= 4; i++) {
-    const y = PAD.top + (chartH / 4) * i;
-    ctx.beginPath(); ctx.moveTo(PAD.left, y); ctx.lineTo(W - PAD.right, y); ctx.stroke();
-  }
-
+  ctx.strokeStyle = 'rgba(255,255,255,0.05)'; ctx.lineWidth = 1;
+  for (let i = 0; i <= 4; i++) { const y = PAD.top + (chartH/4)*i; ctx.beginPath(); ctx.moveTo(PAD.left, y); ctx.lineTo(W-PAD.right, y); ctx.stroke(); }
   ctx.strokeStyle = 'rgba(255,255,255,0.15)';
-  ctx.beginPath(); ctx.moveTo(PAD.left, PAD.top); ctx.lineTo(PAD.left, H - PAD.bottom); ctx.stroke();
-  ctx.beginPath(); ctx.moveTo(PAD.left, H - PAD.bottom); ctx.lineTo(W - PAD.right, H - PAD.bottom); ctx.stroke();
-
+  ctx.beginPath(); ctx.moveTo(PAD.left, PAD.top); ctx.lineTo(PAD.left, H-PAD.bottom); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(PAD.left, H-PAD.bottom); ctx.lineTo(W-PAD.right, H-PAD.bottom); ctx.stroke();
   const y50 = PAD.top + chartH * 0.5;
-  ctx.strokeStyle = 'rgba(255,214,0,0.2)';
-  ctx.setLineDash([4,4]);
-  ctx.beginPath(); ctx.moveTo(PAD.left, y50); ctx.lineTo(W - PAD.right, y50); ctx.stroke();
+  ctx.strokeStyle = 'rgba(255,214,0,0.2)'; ctx.setLineDash([4,4]);
+  ctx.beginPath(); ctx.moveTo(PAD.left, y50); ctx.lineTo(W-PAD.right, y50); ctx.stroke();
   ctx.setLineDash([]);
-
   function xPos(i) { return PAD.left + (i / Math.max(nd-1,1)) * chartW; }
   function yPosWR(v) { return PAD.top + chartH - (v / 100) * chartH; }
-
   if (nd > 1) {
-    const grad = ctx.createLinearGradient(0, PAD.top, 0, H - PAD.bottom);
-    grad.addColorStop(0, 'rgba(0,212,255,0.25)');
-    grad.addColorStop(1, 'rgba(0,212,255,0.01)');
+    const grad = ctx.createLinearGradient(0, PAD.top, 0, H-PAD.bottom);
+    grad.addColorStop(0, 'rgba(0,191,255,0.25)');
+    grad.addColorStop(1, 'rgba(0,191,255,0.01)');
     ctx.fillStyle = grad;
     ctx.beginPath();
     ctx.moveTo(xPos(0), yPosWR(wrs[0]));
     for (let i = 1; i < nd; i++) ctx.lineTo(xPos(i), yPosWR(wrs[i]));
-    ctx.lineTo(xPos(nd-1), H - PAD.bottom);
-    ctx.lineTo(xPos(0), H - PAD.bottom);
+    ctx.lineTo(xPos(nd-1), H-PAD.bottom); ctx.lineTo(xPos(0), H-PAD.bottom);
     ctx.closePath(); ctx.fill();
-
-    ctx.strokeStyle = '#00d4ff';
-    ctx.lineWidth = 2;
+    ctx.strokeStyle = '#00bfff'; ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(xPos(0), yPosWR(wrs[0]));
     for (let i = 1; i < nd; i++) ctx.lineTo(xPos(i), yPosWR(wrs[i]));
     ctx.stroke();
-
-    wrs.forEach((v, i) => {
-      ctx.fillStyle = '#00d4ff';
-      ctx.beginPath();
-      ctx.arc(xPos(i), yPosWR(v), 3, 0, Math.PI * 2);
-      ctx.fill();
-    });
+    wrs.forEach((v, i) => { ctx.fillStyle = '#00bfff'; ctx.beginPath(); ctx.arc(xPos(i), yPosWR(v), 3, 0, Math.PI*2); ctx.fill(); });
   }
-
-  ctx.fillStyle = 'rgba(138,155,184,0.7)';
-  ctx.font = '9px DM Mono, monospace';
-  ctx.textAlign = 'center';
+  ctx.fillStyle = 'rgba(124,135,150,0.7)'; ctx.font = '9px monospace'; ctx.textAlign = 'center';
   const step = Math.ceil(nd / 10);
-  dates.forEach((d, i) => {
-    if (i % step === 0) {
-      ctx.fillText(d.replace('2026_','').replace(/_/g,'/'), xPos(i), H - PAD.bottom + 18);
-    }
-  });
-
+  dates.forEach((d, i) => { if (i % step === 0) ctx.fillText(d.replace('2026_','').replace(/_/g,'/'), xPos(i), H-PAD.bottom+18); });
   ctx.textAlign = 'right';
-  for (let i = 0; i <= 4; i++) {
-    const v = 100 - (100/4)*i;
-    ctx.fillText(v.toFixed(0)+'%', PAD.left - 8, PAD.top + (chartH/4)*i + 4);
-  }
+  for (let i = 0; i <= 4; i++) { const v = 100-(100/4)*i; ctx.fillText(v.toFixed(0)+'%', PAD.left-8, PAD.top+(chartH/4)*i+4); }
 }
-
 function sortTable(th) {
-  const table = th.closest('table');
-  const tbody = table.querySelector('tbody');
+  const tbody = th.closest('table').querySelector('tbody');
   const rows = Array.from(tbody.querySelectorAll('tr'));
   const idx = Array.from(th.parentElement.children).indexOf(th);
-  const asc = th.dataset.asc !== 'true';
-  th.dataset.asc = asc;
+  const asc = th.dataset.asc !== 'true'; th.dataset.asc = asc;
   rows.sort((a, b) => {
     const av = a.cells[idx]?.textContent.replace(/[%+,]/g,'').trim();
     const bv = b.cells[idx]?.textContent.replace(/[%+,]/g,'').trim();
     const an = parseFloat(av), bn = parseFloat(bv);
-    if (!isNaN(an) && !isNaN(bn)) return asc ? an - bn : bn - an;
+    if (!isNaN(an) && !isNaN(bn)) return asc ? an-bn : bn-an;
     return asc ? av.localeCompare(bv) : bv.localeCompare(av);
   });
   rows.forEach(r => tbody.appendChild(r));
 }
-
-window.addEventListener('resize', () => {
-  if (D['nhl_summary_by_date']) renderDateChart();
-});
-
+window.addEventListener('resize', () => { if (D['nhl_summary_by_date']) renderDateChart(); });
 loadAll();
 </script>
 </body>


### PR DESCRIPTION
- Replace inline styles and old CSS vars with matstheme.css + dashboard.css
- Add nav-placeholder div and nav.js injection to all 3 dashboards
- Replace <nav> with <div class="dash-tabs"> to avoid showSection conflict
- Fix showSection to target .dash-tabs a instead of nav a
- Set per-sport --sport-accent CSS vars (NHL: blue, NBA: orange, NCAAB: purple)

https://claude.ai/code/session_01QsGTwGFRYcLQvn7YAguNyZ